### PR TITLE
Fix average time condition

### DIFF
--- a/day1_2_caculate_average_time.ipynb
+++ b/day1_2_caculate_average_time.ipynb
@@ -38,7 +38,7 @@
     "            print(\"error happened\", e)\n",
     "            \n",
     "            \n",
-    "    if number_of_runs > 1:\n",
+    "    if number_of_runs > 0:\n",
     "        average_time = (total_time / number_of_runs)\n",
     "        \n",
     "    else:\n",


### PR DESCRIPTION
## Summary
- fix conditional for average time calculation when only one run is entered

## Testing
- `jq '.' day1_2_caculate_average_time.ipynb > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68402b09cbf0833396611481d7ad9ce0