### PR TITLE
Fix explanation text in notebook

### DIFF
--- a/day1_1_sum_number.ipynb
+++ b/day1_1_sum_number.ipynb
@@ -54,8 +54,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# explonation\n",
-    "### when used (*number), it let your all input number to be \"tuple\", you can input number what you want with no limitation(and also no length limitation)"
+    "# Explanation\n",
+    "When using `*numbers`, all inputs are collected into a tuple so you can pass any amount of numbers without a length limit."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- correct typo in day1_1_sum_number notebook
- clarify wording about using `*numbers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402c1d8b0c8333abe51d7b37aabe7d